### PR TITLE
Add leadership team section to About page

### DIFF
--- a/app/about/page.js
+++ b/app/about/page.js
@@ -2,9 +2,32 @@
 
 import Hero from '@/components/Hero';
 import styles from './page.module.css';
-import { TbShield, TbTarget, TbHeartHandshake } from 'react-icons/tb';
+import { TbShield, TbTarget, TbHeartHandshake, TbBrandLinkedin } from 'react-icons/tb';
 
 const ICON_SIZE = 36;
+
+const team = [
+  {
+    name: 'Austin Brown',
+    title: 'Owner / CEO',
+    linkedin: 'https://www.linkedin.com/in/austin-brown-b5897b90/',
+  },
+  {
+    name: 'Jude Latiolais',
+    title: 'Vice President of Corporate Operations',
+    linkedin: 'https://www.linkedin.com/in/jude-latiolais-6a8a8b90/',
+  },
+  {
+    name: 'Tyler Urbina',
+    title: 'Executive Vice President of Operations',
+    linkedin: 'https://www.linkedin.com/in/tyler-urbina-88b03473/',
+  },
+  {
+    name: 'Zachary Gray',
+    title: 'Vice President of Measurement',
+    linkedin: 'https://www.linkedin.com/in/zachary-gray-9b834a121/',
+  },
+];
 
 export default function AboutPage() {
   return (
@@ -72,6 +95,31 @@ export default function AboutPage() {
                 transparent pricing, and consistent delivery on our promises.
               </p>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.team}>
+        <div className={styles.teamInner}>
+          <h2 className="sectionTitle">Leadership Team</h2>
+          <p className="sectionSubtitle" style={{ margin: '0 auto 48px' }}>
+            Our deep knowledge of custody transfer liquid measurement coupled with extensive experience in LACT and terminal services truly sets us apart.
+          </p>
+          <div className={styles.teamGrid}>
+            {team.map((member, i) => (
+              <div key={i} className={styles.teamCard}>
+                <div className={styles.teamAvatar}>
+                  {member.name.split(' ').map(n => n[0]).join('')}
+                </div>
+                <h3>{member.name}</h3>
+                <p className={styles.teamTitle}>{member.title}</p>
+                {member.linkedin && (
+                  <a href={member.linkedin} target="_blank" rel="noopener noreferrer" className={styles.teamLinkedin}>
+                    <TbBrandLinkedin size={20} /> LinkedIn
+                  </a>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/app/about/page.module.css
+++ b/app/about/page.module.css
@@ -110,6 +110,82 @@
   line-height: 1.6;
 }
 
+/* Team */
+.team {
+  padding: 80px 0;
+}
+
+.teamInner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 24px;
+  text-align: center;
+}
+
+.teamGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+}
+
+.teamCard {
+  background: var(--color-white);
+  padding: 40px 24px;
+  border: 1px solid var(--color-gray-light);
+  text-align: center;
+  transition: all 0.3s ease;
+}
+
+.teamCard:hover {
+  border-color: var(--color-primary);
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+}
+
+.teamAvatar {
+  width: 80px;
+  height: 80px;
+  background: var(--color-dark);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-primary);
+  font-family: var(--font-heading);
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  margin: 0 auto 20px;
+}
+
+.teamCard h3 {
+  font-size: 1.1rem;
+  color: var(--color-dark);
+  margin-bottom: 8px;
+}
+
+.teamTitle {
+  font-size: 0.85rem;
+  color: var(--color-gray);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+
+.teamLinkedin {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.teamLinkedin:hover {
+  opacity: 0.8;
+}
+
 /* Equipment */
 .equipment {
   padding: 80px 0;
@@ -184,6 +260,16 @@
   }
 
   .valuesGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .teamGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .teamGrid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Added a Leadership Team section to the About page between Core Values and Equipment
- 4 team members from the original website: Austin Brown (CEO), Jude Latiolais (VP Corporate Ops), Tyler Urbina (EVP Operations), Zachary Gray (VP Measurement)
- Each card shows initials avatar, name, title, and LinkedIn link
- Responsive: 4-column on desktop, 2-column on tablet, 1-column on mobile

## Test plan
- [ ] Verify team section renders on /about between Core Values and Equipment
- [ ] Check all 4 team member cards display correctly
- [ ] Verify LinkedIn links open in new tab
- [ ] Test mobile and tablet responsive layouts

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)